### PR TITLE
feat: add Helm resource policy annotation for PVC

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.9.0
+version: 0.9.1
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
@@ -6,6 +6,10 @@ metadata:
   name: cloud-volume
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
+  annotations:
+  {{- if .Values.fileStorage.resourcePolicy }}
+    helm.sh/resource-policy: {{ .Values.fileStorage.resourcePolicy | quote }}
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -121,6 +121,7 @@ ingress:
 fileStorage:
   storageClassName: ''
   size: '30Gi'
+  resourcePolicy: ''
 
 awsS3:
   enabled: false


### PR DESCRIPTION
Setting `resourcePolicy` to `"keep"` would allow to retain PVC when Helm release is being deleted. Might be handy when recreating whole Helm release.