### PR TITLE
Fail build with incorrect label location

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.9.2
+version: 0.9.3
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: nx-cloud-file-server
   labels:
-    {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -22,6 +21,7 @@ spec:
     metadata:
       labels:
         app: nx-cloud-file-server
+        {{- include "nxCloud.app.labels" . | indent 4 }}
     spec:
       volumes:
         - name: data


### PR DESCRIPTION
This is a second demo of the builds failing using another real-world example
