### PR TITLE
feat: support self signed certs on github gitlab bitbucket instances

### DIFF
--- a/PROXY-GUIDE.md
+++ b/PROXY-GUIDE.md
@@ -41,32 +41,28 @@ If you have an HTTP proxy, you will need to configure the runner to use your pro
       },
     ```
 
-## External S3 bucket
+## Proxies and external services support (S3, Github etc.) 
 
 If you have an internal cluster but are using an external S3 bucket, then your proxy might block connections 
-from the NxAPI to your S3 bucket.
+from the NxAPI to your S3 bucket. The same issue will happen with connection to your Github/Gitlab instance.
 
-For that, you can try forcing the connection to bypass the proxy by setting the [`NO_PROXY=amazonaws.com`](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/) env var on your
+For that, you can try forcing the connection to bypass the proxy by setting the [`NO_PROXY=amazonaws.com,your-github-instance.com`](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/) env var on your
 NxAPI pods.
+
+
 
 ## Supporting Self-Signed SSL Certificates
 
 If you are using a self-hosted Gitlab or Github instance, or a proxy, you will need to provide the extra CAs
 to NxCloud pods.
 
-There are two pods that will talk to your GitHub/Gitlab instance, and they both need to be made aware 
-of the location of your certificate:
-1. `nx-cloud-api`: this is Node based backend. 
-   1. If you are using self-signed certs on your GitHub instance
-      1. You will need to set `NODE_EXTRA_CA_CERTS=./path-to-ca.pem` on it
-      2. And make sure the `.pem` file is available on the pod's filesystem
-   2. If you are using a proxy
-      1. you can try adding the `NO_PROXY=your-github-instance.com` env var to your pod, or the `NODE_EXTRA_CA_CERTS=./path-to-ca.pem` path to your proxy CA
-2. `nx-cloud-nx-api`: this is a Java based backend
-   1. If you are using a self-signed certs on your GitHub instance
-      1. [Expose your root CA to the JVM](https://stackoverflow.com/a/4326346)
-   2. If you are using a proxy
-      1. You can try adding the `NO_PROXY=your-github-instance.com` env var to the pod
+1. Upload your cert as a ConfigMap
 
+   ```bash
+   kubectl create configmap self-signed-certs --from-file=self-signed-cert.crt=./cert.pem
+   ```
 
-
+2. Point your Helm values to the config map:
+   ```yaml
+   selfSignedCertConfigMap: 'self-signed-certs'
+   ```

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.9.2
+version: 0.9.3
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-api-deployment.yaml
@@ -45,7 +45,16 @@ spec:
             failureThreshold: 5
             periodSeconds: 10
           {{- end}}
+          {{- if .Values.selfSignedCertConfigMap }}
+          volumeMounts:
+            - mountPath: /self-signed-certs
+              name: self-signed-certs-volume
+          {{- end}}
           env:
+            {{- if .Values.selfSignedCertConfigMap }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /self-signed-certs/self-signed-cert.crt
+            {{- end}}
           {{- include "nxCloud.env.nxCloudAppUrl" . | indent 12 }}
           {{- include "nxCloud.env.mongoSecrets" . | indent 12 }}
           {{- include "nxCloud.env.mode" . | indent 12 }}
@@ -200,3 +209,9 @@ spec:
                   name: {{ .Values.secret.name }}
                   key: ROLLBAR_TOKEN
         {{- end }}
+      {{- if .Values.selfSignedCertConfigMap }}
+      volumes:
+        - configMap:
+            name: {{ .Values.selfSignedCertConfigMap }}
+          name: self-signed-certs-volume
+      {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
@@ -6,8 +6,8 @@ metadata:
   name: cloud-volume
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
-  annotations:
   {{- if .Values.fileStorage.resourcePolicy }}
+  annotations:
     helm.sh/resource-policy: {{ .Values.fileStorage.resourcePolicy | quote }}
   {{- end }}
 spec:

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -35,6 +35,32 @@ spec:
           {{- end }}
           ports:
             - containerPort: 4203
+          {{- if .Values.selfSignedCertConfigMap }}
+          # if they have certificates and we need to wait on a post-start hook
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - ./srv/import-all-java-certs.sh /self-signed-certs/self-signed-cert.crt
+          volumeMounts:
+            - mountPath: /self-signed-certs
+              name: self-signed-certs-volume
+          startupProbe:
+            httpGet:
+              path: /nx-cloud/uptime-check
+              port: 4203
+            initialDelaySeconds: 60
+            failureThreshold: 5
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /nx-cloud/uptime-check
+              port: 4203
+            initialDelaySeconds: 120
+          {{- else}}
+          # if we don't need on a post-start hook
           startupProbe:
             httpGet:
               path: /nx-cloud/uptime-check
@@ -47,6 +73,7 @@ spec:
               path: /nx-cloud/uptime-check
               port: 4203
             initialDelaySeconds: 30
+          {{- end}}
           env:
           {{- include "nxCloud.env.nxCloudAppUrl" . | indent 12 }}
           {{- include "nxCloud.api.scm.githubAppEnv" . | indent 12 }}
@@ -148,3 +175,13 @@ spec:
                   name: {{ .Values.secret.name }}
                   key: ROLLBAR_TOKEN
         {{- end }}
+        {{- if .Values.selfSignedCertConfigMap }}
+            - name: NX_CLOUD_NX_API_STARTUP_DELAY_SECONDS
+              value: '90'
+        {{- end }}
+      {{- if .Values.selfSignedCertConfigMap }}
+      volumes:
+        - configMap:
+            name: {{ .Values.selfSignedCertConfigMap }}
+          name: self-signed-certs-volume
+      {{- end }}


### PR DESCRIPTION
The Frontend/BFF API and the Nx API need to connect to github/gitlab so they can post PR comments. If the Github instance is self-hosted with a self-signed certificate, those calls fail, because the CA is not among the known trusted ones.

This PR adds support for dealing with self-signed certificates on self-hosted github/gitlab instances, by allowing users to upload their certificate authority and instruct the pods to use it.

