### PR TITLE
feat(templates): Add ability to override messagequeue image spec

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.9.3
+version: 0.10.0
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/_images.yml
+++ b/charts/nx-cloud/templates/_images.yml
@@ -61,3 +61,10 @@ Return proper aggregator image name
 {{- define "nxCloud.images.aggregator.image" }}
 {{- include "nxCloud.images.common" (dict "imageRoot" .Values.aggregator.image "global" .Values.global "image" .Values.image) }}
 {{- end }}
+
+{{/*
+Return proper messagequeue image name
+*/}}
+{{- define "nxCloud.images.messagequeue.image" }}
+{{- include "nxCloud.images.common" (dict "imageRoot" .Values.messagequeue.image "global" .Values.global "image" .Values.image) }}
+{{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
         - name: nx-cloud-messagequeue
-          image: nxprivatecloud/nx-cloud-messagequeue:latest
-          imagePullPolicy: Always
+          image: {{ include "nxCloud.images.messagequeue.image" . }}
+          imagePullPolicy: {{ .Values.messagequeue.image.pullPolicy | quote }}
           ports:
             - containerPort: 61616
               name: tcp


### PR DESCRIPTION
This replaces the hardcoded image specified in the messagequeue deployment and allows users to override it with a specific image and tag
