### PR TITLE
Fix quoting on cloud mode, was using '' and ""

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.10.1
+version: 0.10.2
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -54,7 +54,7 @@ Below are various little env snippets that multiple mainifests make use of
 {{- define "nxCloud.env.mode" }}
 {{- if .Values.mode }}
 - name: NX_CLOUD_MODE
-  value: '{{ .Values.mode | quote }}'
+  value: {{ .Values.mode | quote }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Typo on my part, did not notice the '' around the value when I piped to `quote`
