### PR TITLE
fix: sets correct namespace on nx-cloud-workflow-controller-rolebinding

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.10.3
+version: 0.10.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-workflow-controller-service-account.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-workflow-controller-service-account.yaml
@@ -50,6 +50,7 @@ metadata:
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
   name: nx-cloud-workflow-controller-rolebinding
+  namespace: {{ .Values.nxCloudWorkflows.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
The rolebinding should be in the same namespace as the role, not the release namespace.