### PR TITLE
feat: adds support for using an external name service for the nx-cloud-workflow-controller

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.10.6
+version: 0.10.7
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: ACTIVEMQ_ADDRESS
               value: tcp://nx-cloud-messagequeue:61616
           {{- end }}
-          {{- if .Values.nxCloudWorkflows.enabled }}
+          {{- if or .Values.nxCloudWorkflows.enabled .Values.nxCloudWorkflows.externalNameService }}
             - name: NX_CLOUD_CI_SERVER_ADDRESS
               value: http://nx-cloud-workflow-controller-service:9000
           {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
@@ -25,5 +25,5 @@ metadata:
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
   type: ExternalName
-  externalName: {{ .Values.nxCloudWorkflows.externalService }}
+  externalName: {{ .Values.nxCloudWorkflows.externalNameService }}
 {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
@@ -14,4 +14,16 @@ spec:
   ports:
     - port: 9000
       targetPort: 9000
+{{- else if .Values.nxCloudWorkflows.externalNameService }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nx-cloud-workflow-controller-service
+  labels:
+    app: nx-cloud-workflow-controller
+    {{- include "nxCloud.app.labels" . | indent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.nxCloudWorkflows.externalService }}
 {{- end }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -124,6 +124,7 @@ nxCloudWorkflowController:
 nxCloudWorkflows:
   enabled: false
   namespace: nx-cloud-workflows
+  externalNameService: ''
 
 replicas:
   frontend: 1


### PR DESCRIPTION
Adds support for setting an external name service for the nx-cloud-workflow-controller.