### PR TITLE
chore(infra): Add initial pre-release flow

### DIFF
--- a/.github/workflows/release_charts.yaml
+++ b/.github/workflows/release_charts.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'prerelease/**'
 
 jobs:
   release:


### PR DESCRIPTION
This will publish charts off of `prerelease/*` branches so we have a way to make new testing releases without merging into main