### PR TITLE
adds support for setting NX_CLOUD_WORKFLOW_CONTROLLER_ADDRESS

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.11.3
+version: 0.11.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
@@ -35,4 +35,8 @@ spec:
           env:
         {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
         {{- include "nxCloud.env.mode" . | indent 12 }}
+        {{- if or .Values.nxCloudWorkflows.enabled .Values.nxCloudWorkflows.externalNameService }}
+          - name: NX_CLOUD_WORKFLOW_CONTROLLER_ADDRESS
+            value: http://nx-cloud-workflow-controller-service:9000
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
We've merged support for viewing logs within the Nx Cloud app so we need to support setting the required config property in the deployment.