### PR TITLE
Suggestion: Use ClusterIP instead of NodePort

### DIFF
--- a/charts/nx-cloud/templates/nx-cloud-api-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-api-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nx-cloud-api
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: nx-cloud-api
   ports:

--- a/charts/nx-cloud/templates/nx-cloud-file-server-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: nx-cloud-file-server
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: nx-cloud-file-server
   ports:

--- a/charts/nx-cloud/templates/nx-cloud-frontend-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nx-cloud-frontend
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: nx-cloud-frontend
   ports:

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nx-cloud-nx-api
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: nx-cloud-nx-api
   ports:


### PR DESCRIPTION
NodePort is not necessary in any of those cases, as these services are exposed directly via Ingress, anyway. Additionally, since the NodePort is likely allocated without the knowledge of the end-user, this could cause situations where the deployed NX Cloud service is unexpectedly exposed publicly.

Using a service of type ClusterIP instead fixes the issue while ensuring that services aren't exposed by accident.