### PR TITLE
chore(charts): ensure env and envFrom can be set, move env to deployment

### DIFF
--- a/.github/workflows/chart_lint_and_test.yaml
+++ b/.github/workflows/chart_lint_and_test.yaml
@@ -44,6 +44,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           cp testing-files/secret.yml charts/nx-cloud/templates/secret.yaml
+          cp testing-files/secret.yml charts/nx-agents/templates/secret.yaml
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # We copy this over on automated testing but for local we need to copy it in so ignore
 # if someone forgets to delete before pushing
 charts/nx-cloud/templates/secret.yml
+charts/nx-agents/templates/secret.yml

--- a/charts/nx-agents/Chart.yaml
+++ b/charts/nx-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-agents
 description: Nx Cloud Agents Helm Chart
 type: application
-version: 1.0.0-rc.3
+version: 1.0.0-rc.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-agents/ci/basic-moreenv.yaml
+++ b/charts/nx-agents/ci/basic-moreenv.yaml
@@ -18,7 +18,16 @@ controller:
   deployment:
     port: 9000
     annotations: {}
-    env: {}
+    env:
+      - name: value-one
+        value: nx-cloud-workflows
+      - name: value-two
+        value: nx-cloud-workflows2
+    envFrom:
+      - configMapRef:
+          name: configmap
+      - secretRef:
+          name: secret
   service:
     port: 9000
     type: ClusterIP

--- a/charts/nx-agents/ci/basic-moreenv.yaml
+++ b/charts/nx-agents/ci/basic-moreenv.yaml
@@ -67,5 +67,5 @@ daemonset:
 
 secret:
   name: 'cloudsecret'
-  awsS3AccessKeyId: 'ABC123556'
-  awsS3SecretAccessKey: 'BBBAAA1234'
+  awsS3AccessKeyId: 'AWS_KEY'
+  awsS3SecretAccessKey: 'AWS_SECRET'

--- a/charts/nx-agents/ci/basic-values.yaml
+++ b/charts/nx-agents/ci/basic-values.yaml
@@ -58,5 +58,5 @@ daemonset:
 
 secret:
   name: 'cloudsecret'
-  awsS3AccessKeyId: 'ABC123556'
-  awsS3SecretAccessKey: 'BBBAAA1234'
+  awsS3AccessKeyId: 'AWS_KEY'
+  awsS3SecretAccessKey: 'AWS_SECRET'

--- a/charts/nx-agents/templates/deployment.yaml
+++ b/charts/nx-agents/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     matchLabels:
       app: nx-cloud-workflow-controller
   replicas: 1
+  {{- if .Values.controller.deployment.strategy }}
+  strategy:
+    {{- toYaml .Values.controller.deployment.strategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -69,6 +73,7 @@ spec:
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 1
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /readyz
@@ -78,26 +83,27 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          {{- if gt (len .Values.controller.env) 0 }}
-          env:
-          {{- range $key, $value := .Values.controller.env }}
-          - name: {{ $key | quote }}
-            value: {{ $value | quote }}
+          {{- if gt (len .Values.controller.deployment.envFrom) 0 }}
+          envFrom:
+            {{- toYaml .Values.controller.deployment.envFrom | nindent 12}}
           {{- end }}
+          env:
+          {{- if gt (len .Values.controller.deployment.env) 0 }}
+            {{- toYaml .Values.controller.deployment.env | nindent 12 }}
+          {{- end }}          
           {{- with .Values.secret }}
           {{- if .awsS3AccessKeyId }}
           {{- if .name }}
-          - name: AWS_S3_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: {{ .name }}
-                key: {{ .awsS3AccessKeyId }}
-          - name: AWS_S3_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ .name }}
-                key: {{ .awsS3SecretAccessKey }}
-          {{- end }}
+            - name: AWS_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .awsS3AccessKeyId }}
+            - name: AWS_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .awsS3SecretAccessKey }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/charts/nx-agents/values.yaml
+++ b/charts/nx-agents/values.yaml
@@ -24,13 +24,19 @@ controller:
     tolerations: {}
     nodeSelector: {}
     args: {}
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    envFrom: []
+    env: {}
   service:
     port: 9000
     type: ClusterIP
     loadBalancerIP: ''
     loadBalancerSourceRanges: []
     annotations: {}
-  env: {}
   image:
     registry: ''
     imageName: nx-cloud-workflow-controller

--- a/testing-files/secret.yml
+++ b/testing-files/secret.yml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudsecret
+  namespace: {{ .Values.global.namespace }}
 type: Opaque
 stringData:
   NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"
@@ -18,3 +19,5 @@ stringData:
   GITHUB_AUTH_TOKEN: "A_GITHUB_SECRET_VALUE"
   GITHUB_APP_PRIVATE_KEY: "A_GITHUB_SECRET_VALUE"
   GITHUB_APP_ID: "A_GITHUB_SECRET_VALUE"
+  AWS_KEY: "MYAWSKEY"
+  AWS_SECRET: "SUPER_SECRET_AWS_SECRET"


### PR DESCRIPTION
When I went to use the chart, I noticed that we did not provide a way to set envFrom. Then while doing those changes
I also noticed we could just use basic yaml instead of doing an array and trying to pull values. This will keep it 
similar to how one would expect it to be in the final manifest.
