### PR TITLE
fix(charts): reorder default in helpers

### DIFF
--- a/charts/nx-agents/Chart.yaml
+++ b/charts/nx-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-agents
 description: Nx Cloud Agents Helm Chart
 type: application
-version: 1.0.0-rc.4
+version: 1.0.0-rc.5
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-agents/templates/_helpers.tpl
+++ b/charts/nx-agents/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "nxCloud.app.name" }}
-{{- default .Chart.Name .Values.naming.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name | default .Values.naming.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/nx-agents/templates/_images.yml
+++ b/charts/nx-agents/templates/_images.yml
@@ -6,10 +6,10 @@ and modified to support global imageTag
 */}}
 {{- define "nxCloud.images.common" }}
 {{- $registryName := .imageRoot.registry }}
-{{- $repositoryName := default .imageRoot.repository .global.imageRepository }}
+{{- $repositoryName := .imageRoot.repository | default .global.imageRepository }}
 {{- $imageName := .imageRoot.imageName }}
 {{- $separator := ":" }}
-{{- $termination := default .global.imageTag .imageRoot.tag | toString }}
+{{- $termination := .global.imageTag | default .imageRoot.tag | toString }}
 {{- if .global }}
     {{- if .global.imageRegistry }}
      {{- $registryName = .global.imageRegistry }}


### PR DESCRIPTION
It seems there was some issue where the usage of default without a pipe
makes for a strange behaviour. This was causing the default value in global's
image repository to override everything else
