### PR TITLE
Update nx-cloud chart

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.13.2
+version: 0.13.3-rc.1
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.13.3-rc.1
+version: 0.14.0
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/ci/basic-values.yaml
+++ b/charts/nx-cloud/ci/basic-values.yaml
@@ -73,6 +73,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/ci/scm-gh-values.yaml
+++ b/charts/nx-cloud/ci/scm-gh-values.yaml
@@ -51,6 +51,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/ci/scm-gl-values.yaml
+++ b/charts/nx-cloud/ci/scm-gl-values.yaml
@@ -45,6 +45,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/ci/sh-like-values.yaml
+++ b/charts/nx-cloud/ci/sh-like-values.yaml
@@ -72,6 +72,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/ci/wfcontroller-values-externalservice.yaml
+++ b/charts/nx-cloud/ci/wfcontroller-values-externalservice.yaml
@@ -35,12 +35,13 @@ aggregator:
       cpu: '0.1'
 
 nxCloudWorkflows:
-  namespace: ''
-  createNamespace: false
-  service:
-    enabled: true
-    name: 'nx-cloud-workflow-controller-service'
-    externalName: '192.168.1.2'
+  enabled: true
+  port: 9000
+  name: 'nx-cloud-workflow-controller-service'
+  workflowsNamespace: 'nx-cloud-workflows'
+
+  externalName: '10.0.0.64'
+
 
 extraManifests:
   secret:
@@ -48,6 +49,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/ci/wfcontroller-values.yaml
+++ b/charts/nx-cloud/ci/wfcontroller-values.yaml
@@ -35,12 +35,12 @@ aggregator:
       cpu: '0.1'
 
 nxCloudWorkflows:
-  namespace: 'nx-cloud-workflows'
-  createNamespace: true
-  service:
-    enabled: true
-    name: 'nx-cloud-workflow-controller-service'
-    externalName: ''
+  enabled: true
+  port: 9000
+  name: 'nx-cloud-workflow-controller-service'
+  workflowsNamespace: 'nx-cloud-workflows'
+
+  externalName: ''
 
 extraManifests:
   secret:
@@ -48,6 +48,7 @@ extraManifests:
     kind: Secret
     metadata:
       name: cloudsecret
+      namespace: default
     type: Opaque
     stringData:
       NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -95,26 +95,14 @@ Below are various little env snippets that multiple mainifests make use of
 {{- end }}
 {{- end }}
 
-{{- define "nxCloud.env.seqValues" }}
-{{- if and .Values.seqServerAddress (.Values.secret).seqApiKey }}
-- name: NX_CLOUD_SEQ_ADDRESS
-  value: {{ .Values.seqServerAddress | quote }}
-- name: NX_CLOUD_SEQ_KEY
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.secret.name }}
-      key: {{ .Values.secret.seqApiKey }}
-{{- end }}
-{{- end }}
-
 {{- define "nxCloud.workflows.serviceTarget" }}
-{{- if .Values.nxCloudWorkflows.service.enabled}}
-{{- if.Values.nxCloudWorkflows.namespace }}
+{{- if .Values.nxCloudWorkflows.enabled}}
+{{- if eq .Values.nxCloudWorkflows.externalName ""}}
 - name: NX_CLOUD_WORKFLOW_CONTROLLER_ADDRESS
-  value: http://{{ .Values.nxCloudWorkflows.service.name }}.{{ .Values.nxCloudWorkflows.namespace }}.svc.cluster.local:9000
+  value: http://{{ .Values.nxCloudWorkflows.name }}.{{ .Values.nxCloudWorkflows.workflowsNamespace }}.svc.cluster.local:{{ .Values.nxCloudWorkflows.port }}
 {{- else }}
 - name: NX_CLOUD_WORKFLOW_CONTROLLER_ADDRESS
-  value: http://{{ .Values.nxCloudWorkflows.service.name }}:9000
+  value: http://{{ .Values.nxCloudWorkflows.name }}:{{ .Values.nxCloudWorkflows.port }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -26,7 +26,6 @@ spec:
           {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
           {{- include "nxCloud.env.mode" . | indent 12 }}
           {{- include "nxCloud.env.verboseMongoLogging" . | indent 12 }}
-          {{- include "nxCloud.env.seqValues" . | indent 12 }}
           {{- if .Values.aggregator.env}}
             {{- toYaml .Values.aggregator.env | nindent 12 }}
           {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nx-cloud-file-server
+  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:

--- a/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: cloud-volume
+  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
   {{- if .Values.fileStorage.resourcePolicy }}

--- a/charts/nx-cloud/templates/nx-cloud-file-server-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fileServer.service.name }}
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-file-server
     {{- include "nxCloud.app.labels" . | indent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nx-cloud-frontend
+  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:

--- a/charts/nx-cloud/templates/nx-cloud-frontend-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.frontend.service.name }}
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-frontend
     {{- include "nxCloud.app.labels" . | indent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-ingress.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nx-cloud-ingress
+  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nx-cloud-messagequeue
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-messagequeue
     {{- include "nxCloud.app.labels" . | indent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-message-queue-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-message-queue-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.messagequeue.service.name }}
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-messagequeue
     {{- include "nxCloud.app.labels" . | indent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nx-cloud-nx-api
+  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
@@ -85,7 +86,6 @@ spec:
           {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
           {{- include "nxCloud.env.verboseMongoLogging" . | indent 12 }}
           {{- include "nxCloud.env.mongoSecrets" . | indent 12 }}
-          {{- include "nxCloud.env.seqValues" . | indent 12 }}
           {{- include "nxCloud.workflows.serviceTarget" . | indent 12 }}
           {{- if .Values.nxApi.deployment.env }}
             {{- toYaml .Values.nxApi.deployment.env | nindent 12 }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.nxApi.service.name }}
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-nx-api
     {{- include "nxCloud.app.labels" . | indent 4 }}

--- a/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-workflow-controller-service.yaml
@@ -1,34 +1,16 @@
-{{- if .Values.nxCloudWorkflows.service.enabled }}
+{{- if and .Values.nxCloudWorkflows.enabled .Values.nxCloudWorkflows.externalName }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.nxCloudWorkflows.service.name }}
-  {{- if .Values.nxCloudWorkflows.namespace }}
-  namespace: {{ .Values.nxCloudWorkflows.namespace }}
-  {{- end }}
+  name: {{ .Values.nxCloudWorkflows.name }}
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: nx-cloud-workflow-controller
     {{- include "nxCloud.app.labels" . | indent 4 }}
 spec:
-  {{- if .Values.nxCloudWorkflows.service.externalName }}
+  {{- if .Values.nxCloudWorkflows.externalName }}
   type: ExternalName
-  externalName: {{ .Values.nxCloudWorkflows.service.externalName }}
-  {{- else }}
-  type: ClusterIP
-  selector:
-    app: nx-cloud-workflow-controller
-  ports:
-    - port: 9000
-      targetPort: 9000
+  externalName: {{ .Values.nxCloudWorkflows.externalName }}
   {{- end }}
-{{- end }}
-{{- if .Values.nxCloudWorkflows.createNamespace }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.nxCloudWorkflows.namespace }}
-  labels:
-    {{- include "nxCloud.app.labels" . | indent 4 }}
 {{- end }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -130,12 +130,20 @@ messagequeue:
     requests: {}
 
 nxCloudWorkflows:
-  namespace: ''
-  createNamespace: false
-  service:
-    enabled: false
-    name: ''
-    externalName: ''
+  enabled: false
+  port: 9000
+  name: 'nx-cloud-workflow-controller-service'
+  workflowsNamespace: 'nx-cloud-workflows'
+
+
+  # If externalName is left unset, the applications will look for ane existing service with the name defined
+  # by `nxCloudWorkflows.name` in the namespace `nxCloudWorkflows.workflowsNamespace`. Use this option if you are
+  # also running the nx-agents chart in the same cluster as this nx-cloud chart
+  #
+  # If externalName is set, an additional service will be created with the name `nxCloudWorkflows.name`
+  # in the global namespace of this chart, and applications will use that service to connect to the workflow controller.
+  # Use this option if your nx-agents are running in a different cluster than this nx-cloud chart
+  externalName: ''
 
 # Deprecated, use nxApi.deployment.replicas and frontend.deployment.replicas
 replicas:


### PR DESCRIPTION
- use global namespace for all resources
- refactor nxCloudWorkflows to only make a service if it is external. No custom namespace is used