### PR TITLE
chore(agents): add ability to change additional values

### DIFF
--- a/charts/nx-agents/Chart.yaml
+++ b/charts/nx-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-agents
 description: Nx Cloud Agents Helm Chart
 type: application
-version: 1.0.2
+version: 1.1.0
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-agents/ci/more-daemonset.yaml
+++ b/charts/nx-agents/ci/more-daemonset.yaml
@@ -42,7 +42,7 @@ executor:
 daemonset:
   enabled: true
   image:
-    registry: ''
+    registry: 'private.registry.example.com'
     imageName: ubuntu
     repository: ''
     tag: 22.04

--- a/charts/nx-agents/ci/skipnamespace.yaml
+++ b/charts/nx-agents/ci/skipnamespace.yaml
@@ -1,5 +1,6 @@
 global:
   namespace: 'nx-cloud-workflows'
+  createNamespace: false
 
 naming:
   nameOverride: ''
@@ -42,7 +43,7 @@ executor:
 daemonset:
   enabled: true
   image:
-    registry: ''
+    registry: 'private.registry.example.com'
     imageName: ubuntu
     repository: ''
     tag: 22.04
@@ -74,3 +75,10 @@ extraManifests:
     stringData:
       AWS_KEY: "MYAWSKEY"
       AWS_SECRET: "SUPER_SECRET_AWS_SECRET"
+  namespace:
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: nx-cloud-workflows
+      labels:
+        my.lbael: "true"

--- a/charts/nx-agents/templates/_images.yml
+++ b/charts/nx-agents/templates/_images.yml
@@ -13,10 +13,12 @@ with the entire global option removed
     {{- $separator = "@" }}
     {{- $termination = .imageRoot.digest | toString }}
 {{- end }}
-{{- if $registryName }}
+{{- if and $registryName $repositoryName }}
     {{- printf "%s/%s/%s%s%s" $registryName $repositoryName $imageName $separator $termination }}
+{{- else if $repositoryName }}
+    {{- printf "%s/%s%s%s" $repositoryName $imageName $separator $termination }}
 {{- else }}
-    {{- printf "%s/%s%s%s"  $repositoryName $imageName $separator $termination }}
+    {{- printf "%s%s%s"  $imageName $separator $termination }}
 {{- end }}
 {{- end }}
 
@@ -26,4 +28,8 @@ Return proper nx-cloud-workflow-controller image name
 */}}
 {{- define "nxCloud.images.workflowController.image" }}
 {{- include "nxCloud.images.common" (dict "imageRoot" .Values.controller.image) }}
+{{- end }}
+
+{{- define "nxCloud.images.daemonset.image" }}
+{{- include "nxCloud.images.common" (dict "imageRoot" .Values.daemonset.image) }}
 {{- end }}

--- a/charts/nx-agents/templates/daemonset.yaml
+++ b/charts/nx-agents/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: nx-cloud-workflows-daemon
-        image: ubuntu:22.04
+        image: {{ include "nxCloud.images.daemonset.image" . }}
         command: ["/bin/sh","-c"]
         args: ["/script/daemon.sh; while true; do echo Sleeping && sleep 3600; done"]
         volumeMounts:

--- a/charts/nx-agents/templates/namespace.yaml
+++ b/charts/nx-agents/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.createNamespace }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -5,3 +6,4 @@ metadata:
   name: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
+{{- end }}

--- a/charts/nx-agents/values.yaml
+++ b/charts/nx-agents/values.yaml
@@ -3,6 +3,10 @@ global:
   # created as well as where your agents run.
   namespace: 'nx-cloud-workflows'
 
+  # If you are deploying your the above namespace yourself (e.g. for secrets or other resources), you can
+  # tell this chart not to try and create it for you.
+  createNamespace: true
+
 naming:
   # Overrides the app name (defined in _helpers.tpl) used when installing the chart
   nameOverride: ''
@@ -101,6 +105,11 @@ executor:
 # Additionally this feature can be retained, and you can update the provided script to run other things you would like on
 # each node in your cluster.
 daemonset:
+  image:
+    registry: ''
+    imageName: ubuntu
+    repository: ''
+    tag: 22.04
   enabled: true
   script: |
     #!/bin/bash


### PR DESCRIPTION
It was pointed out that the namespace could not exist prior to installing
the chart. We have added `global.createNamespace` to control this behaviour.

The image used for the daemonset was not configurable, mainly the registry
and repository portion. We have added `daemonset.image` to control this.
