### PR TITLE
Allow Configurable Daemonset Tolerations

### DIFF
--- a/charts/nx-agents/Chart.yaml
+++ b/charts/nx-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-agents
 description: Nx Cloud Agents Helm Chart
 type: application
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-agents/ci/basic-values.yaml
+++ b/charts/nx-agents/ci/basic-values.yaml
@@ -15,7 +15,7 @@ controller:
   deployment:
     port: 9000
     annotations: {}
-    env: {}
+    env: []
   service:
     port: 9000
     type: ClusterIP
@@ -41,6 +41,13 @@ executor:
 
 daemonset:
   enabled: true
+  tolerations:
+    - effect: NoSchedule
+      key: kubernetes.io/arch
+      value: arm64
+    - effect: NoSchedule
+      key: kubernetes.io/arch
+      value: amd64
   image:
     registry: ''
     imageName: ubuntu

--- a/charts/nx-agents/templates/daemonset.yaml
+++ b/charts/nx-agents/templates/daemonset.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         name: nx-cloud-workflows-daemon
     spec:
+      {{- with .Values.daemonset.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: nx-cloud-workflows-daemon
         image: {{ include "nxCloud.images.daemonset.image" . }}

--- a/charts/nx-agents/values.yaml
+++ b/charts/nx-agents/values.yaml
@@ -105,6 +105,7 @@ executor:
 # Additionally this feature can be retained, and you can update the provided script to run other things you would like on
 # each node in your cluster.
 daemonset:
+  tolerations: []
   image:
     registry: ''
     imageName: ubuntu


### PR DESCRIPTION
This is necessary for the Daemonset to run on nodes with taints.