### PR TITLE
fix: remove default imageTag for messagequeue container

### DIFF
--- a/.github/workflows/chart_lint_and_test.yaml
+++ b/.github/workflows/chart_lint_and_test.yaml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config testing-files/ct.yaml --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --config testing-files/ct.yaml --target-branch ${{ github.event.repository.default_branch }} --debug

--- a/.github/workflows/chart_lint_and_test.yaml
+++ b/.github/workflows/chart_lint_and_test.yaml
@@ -12,9 +12,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
-          version: v4.2.0
+          version: v3.15.3
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/chart_lint_and_test.yaml
+++ b/.github/workflows/chart_lint_and_test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.11.2
+          version: v4.2.0
 
       - uses: actions/setup-python@v4
         with:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.10.0
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.2
+version: 0.15.6
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.1
+version: 0.15.2
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/ci/basic-values.yaml
+++ b/charts/nx-cloud/ci/basic-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2406.29.1'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/basic-values.yaml
+++ b/charts/nx-cloud/ci/basic-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2406.29.1'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/endpointslice-values.yaml
+++ b/charts/nx-cloud/ci/endpointslice-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/scm-gh-values.yaml
+++ b/charts/nx-cloud/ci/scm-gh-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/scm-gl-values.yaml
+++ b/charts/nx-cloud/ci/scm-gl-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/sh-like-values.yaml
+++ b/charts/nx-cloud/ci/sh-like-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 verboseLogging: 'true'
 

--- a/charts/nx-cloud/ci/wfcontroller-values-externalservice.yaml
+++ b/charts/nx-cloud/ci/wfcontroller-values-externalservice.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/ci/wfcontroller-values.yaml
+++ b/charts/nx-cloud/ci/wfcontroller-values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageTag: '2308.22.7'
+  imageTag: '2405.02.15'
 
 nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
 

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -114,7 +114,7 @@ messagequeue:
     registry: ''
     imageName: nx-cloud-messagequeue
     repository: ''
-    tag: latest
+    tag: ''
     digest: ''
     pullPolicy: Always
   deployment:

--- a/testing-files/ct.yaml
+++ b/testing-files/ct.yaml
@@ -2,4 +2,4 @@ remote: origin
 target-branch: main
 chart-dirs:
   - charts
-helm-extra-args: --timeout 600s
+helm-extra-args: --timeout 300s


### PR DESCRIPTION
Without the change `messagequeue` ignores the value set on `global.imageTag`:
![image](https://github.com/nrwl/nx-cloud-helm/assets/3633549/776c7407-8d82-42db-b6d6-a51f5d52a9f6)

With the change default image tag version for `messagequeue` remains `latest`, but it also can be overriden by specifying `global.imageTag` (as for all other images):
![image](https://github.com/nrwl/nx-cloud-helm/assets/3633549/2ad978f9-2c12-45e0-b1a1-83f8712bcfce)
