### PR TITLE
re-add nx api probes

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.2
+version: 0.15.3
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -40,8 +40,7 @@ spec:
           volumeMounts:
             - mountPath: /self-signed-certs
               name: self-signed-certs-volume
-          {{- else}}
-          # if we don't need on a post-start hook
+          {{- end}}
           startupProbe:
             httpGet:
               path: /nx-cloud/uptime-check
@@ -54,7 +53,6 @@ spec:
               path: /nx-cloud/uptime-check
               port: {{ .Values.nxApi.deployment.port }}
             initialDelaySeconds: 30
-          {{- end}}
           {{- if .Values.nxApi.deployment.readinessProbe }}
           readinessProbe: {{- toYaml .Values.nxApi.deployment.readinessProbe | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
a badly placed `if / else` caused all the startup probes to disappear when a config map was being used