### PR TITLE
allow custom ca on frontend

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.3
+version: 0.15.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
@@ -44,6 +44,11 @@ spec:
               port: {{ .Values.frontend.deployment.port }}
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- if .Values.selfSignedCertConfigMap }}
+          volumeMounts:
+            - mountPath: /self-signed-certs
+              name: self-signed-certs-volume
+          {{- end}}
           env:
         {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
         {{- include "nxCloud.env.mode" . | indent 12 }}
@@ -55,6 +60,10 @@ spec:
         {{- if .Values.frontend.deployment.env }}
           {{- toYaml .Values.frontend.deployment.env | nindent 12 }}
         {{- end }}
+        {{- if .Values.selfSignedCertConfigMap }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /self-signed-certs/self-signed-cert.crt
+        {{- end}}
         {{- with .Values.secret }}
           {{- if .name }}
             {{- if .githubPrivateKey }}
@@ -80,3 +89,9 @@ spec:
                     {{- end }}
             {{- end }}
         {{- end }}
+      {{- if .Values.selfSignedCertConfigMap }}
+      volumes:
+        - configMap:
+            name: {{ .Values.selfSignedCertConfigMap }}
+          name: self-signed-certs-volume
+      {{- end }}


### PR DESCRIPTION
this is something that [we already support on the nx-api](https://github.com/nrwl/nx-cloud-helm/blob/main/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml#L128-L133) and the aggregator, but was missed from the frontend during a migration