### PR TITLE
chore(app): ensure most specific image spec values have priority

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.7
+version: 0.15.8
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/_images.yml
+++ b/charts/nx-cloud/templates/_images.yml
@@ -6,13 +6,13 @@ and modified to support global imageTag
 */}}
 {{- define "nxCloud.images.common" }}
 {{- $registryName := .imageRoot.registry }}
-{{- $repositoryName := default .imageRoot.repository .global.imageRepository }}
+{{- $repositoryName := default .global.imageRepository .imageRoot.repository }}
 {{- $imageName := .imageRoot.imageName }}
 {{- $separator := ":" }}
 {{- $termination := default .image.tag (default .global.imageTag .imageRoot.tag) | toString }}
 {{- if .global }}
     {{- if .global.imageRegistry }}
-     {{- $registryName = .global.imageRegistry }}
+     {{- $registryName = default .global.imageRegistry $registryName }}
     {{- end }}
 {{- end }}
 {{- if .imageRoot.digest }}


### PR DESCRIPTION
I found that when trying to override a single image for the messagequeue
the global values continued to clobber mine as they are the last value
in the default clause. This moves the specific values to the end of the
default params to ensure if you have a more specific value it will
not be overridden by global values.
