### PR TITLE
chore(app): allow user to define/override MQ volumes

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.8
+version: 0.15.9
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
@@ -26,10 +26,11 @@ spec:
           resources: {{- toYaml .Values.messagequeue.resources | nindent 12 }}
           {{- end }}
           env:
-            - name: ACTIVEMQ_TMP
-              value: /opt/activemq/tmp
             {{- if .Values.messagequeue.deployment.env }}
             {{- toYaml .Values.messagequeue.deployment.env | nindent 12 }}
+            {{- else }}
+            - name: ACTIVEMQ_TMP
+              value: /opt/activemq/tmp
             {{- end }}
           ports:
             - containerPort: {{ .Values.messagequeue.deployment.port }}
@@ -39,13 +40,21 @@ spec:
           {{- toYaml .Values.messagequeue.securityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.messagequeue.deployment.volumeMounts }}
+            {{- toYaml .Values.messagequeue.deployment.volumeMounts | nindent 12 }}
+            {{- else }}
             - mountPath: /opt/activemq/data
               name: data
             - mountPath: /opt/activemq/tmp
               name: tmp
+            {{- end }}
       volumes:
-        - emptyDir: {}
+        {{- if .Values.messagequeue.deployment.volumes }}
+        {{- toYaml .Values.messagequeue.deployment.volumes | nindent 8 }}
+        {{- else }}
+        - emptyDir: { }
           name: data
-        - emptyDir: {}
+        - emptyDir: { }
           name: tmp
+        {{- end }}
 {{- end }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -120,6 +120,8 @@ messagequeue:
   deployment:
     port: 61616
     env: []
+    volumes: {}
+    volumeMounts: {}
   service:
     name: nx-cloud-messagequeue
     type: ClusterIP


### PR DESCRIPTION
With the incoming switch to artemis, we need to be able to override these
values until we do chart 1.0. This should work well enough for us until
that point.
