### PR TITLE
fix(app): ensure invalid keys do not make it through

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.9
+version: 0.15.10
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             periodSeconds: 5
           {{- if .Values.fileServer.securityContext }}
           securityContext:
-          {{- toYaml .Values.fileServer.securityContext | nindent 12 }}
+          {{- omit .Values.fileServer.securityContext "enabled" "fsGroup" "fsGroupChangePolicy" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /data


### PR DESCRIPTION
The 'enabled', 'fsGroup', and 'fsGroupChangePolicy' keys were making it
through to the template.spec.containers[0].securityContext section. This
is causing updates to have issues applying.
