### PR TITLE
chore(nx-cloud): Allow serviceAccountName to be defined for all nx-cloud deployments

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.11
+version: 0.15.12
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/ci/basic-values.yaml
+++ b/charts/nx-cloud/ci/basic-values.yaml
@@ -11,6 +11,7 @@ secret:
 # When creating new values files for testing, bring over the lines below. The generated environment is quite resource
 # constrained and with the default settings from values.yaml some of the pods will fail to schedule.
 frontend:
+  serviceAccountName: 'nx-cloud-sa'
   deployment:
     env:
       - name: TEST_VARIABLE
@@ -24,6 +25,7 @@ frontend:
       cpu: '0.1'
 
 nxApi:
+  serviceAccountName: 'nx-cloud-sa'
   deployment:
     env:
       - name: TEST_VARIABLE
@@ -37,6 +39,7 @@ nxApi:
       cpu: '0.1'
 
 fileServer:
+  serviceAccountName: 'nx-cloud-sa'
   deployment:
     env:
       - name: TEST_VARIABLE
@@ -52,6 +55,7 @@ fileServer:
       cpu: '0.1'
 
 aggregator:
+  serviceAccountName: 'nx-cloud-sa'
   schedule: "*/10 * * * *"
   env:
     - name: TEST_VARIABLE
@@ -62,12 +66,19 @@ aggregator:
       cpu: '0.1'
 
 messagequeue:
+  serviceAccountName: 'nx-cloud-sa'
   deployment:
     port: 61616
   service:
     port: 61616
 
 extraManifests:
+  serviceAccount:
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: nx-cloud-sa
+      namespace: default
   secret:
     apiVersion: v1
     kind: Secret

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -2,6 +2,9 @@
 spec:
   template:
     spec:
+      {{- if .Values.aggregator.serviceAccountName }}
+      serviceAccountName: {{ .Values.aggregator.serviceAccountName }}
+      {{- end }}
       {{- if .Values.selfSignedCertConfigMap }}
       initContainers:
         - command:

--- a/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-file-server-deployment.yaml
@@ -24,6 +24,9 @@ spec:
       labels:
         app: nx-cloud-file-server
     spec:
+      {{- if .Values.fileServer.serviceAccountName }}
+      serviceAccountName: {{ .Values.fileServer.serviceAccountName }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app: nx-cloud-frontend
     spec:
+      {{- if .Values.frontend.serviceAccountName }}
+      serviceAccountName: {{ .Values.frontend.serviceAccountName }}
+      {{- end }}
       containers:
         - name: nx-cloud-frontend
           image: {{ include "nxCloud.images.frontend.image" . }}

--- a/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-message-queue-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: nx-cloud-messagequeue
     spec:
+      {{- if .Values.messagequeue.serviceAccountName }}
+      serviceAccountName: {{ .Values.messagequeue.serviceAccountName }}
+      {{- end }}
       containers:
         - name: nx-cloud-messagequeue
           image: {{ include "nxCloud.images.messagequeue.image" . }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -24,7 +24,11 @@ spec:
         app: nx-cloud-nx-api
     spec:
       terminationGracePeriodSeconds: 60
-      {{- if .Values.awsS3.serviceAccountName }}
+      {{- if and .Values.nxApi.serviceAccountName .Values.awsS3.serviceAccountName }}
+      serviceAccountName: {{ .Values.nxApi.serviceAccountName }}
+      {{- else if .Values.nxApi.serviceAccountName }}
+      serviceAccountName: {{ .Values.nxApi.serviceAccountName }}
+      {{- else if .Values.awsS3.serviceAccountName }}
       serviceAccountName: {{ .Values.awsS3.serviceAccountName }}
       {{- end }}
       {{- if .Values.selfSignedCertConfigMap }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -19,6 +19,7 @@ verboseMongoLogging: false
 enableMessageQueue: true
 
 frontend:
+  serviceAccountName: ''
   image:
     registry: ''
     imageName: nx-cloud-frontend
@@ -42,6 +43,7 @@ frontend:
       cpu: '0.5'
 
 nxApi:
+  serviceAccountName: ''
   image:
     registry: ''
     imageName: nx-cloud-nx-api
@@ -66,6 +68,7 @@ nxApi:
       cpu: '1.0'
 
 fileServer:
+  serviceAccountName: ''
   image:
     registry: ''
     imageName: nx-cloud-file-server
@@ -94,6 +97,7 @@ fileServer:
     fsGroupChangePolicy: "OnRootMismatch"
 
 aggregator:
+  serviceAccountName: ''
   schedule: '*/10 * * * *'
   image:
     registry: ''
@@ -110,6 +114,7 @@ aggregator:
       cpu: '0.5'
 
 messagequeue:
+  serviceAccountName: ''
   image:
     registry: ''
     imageName: nx-cloud-messagequeue


### PR DESCRIPTION
Removes the (undocumented) awsS3.serviceAccountName.