### PR TITLE
fix executor binary deployment property references

### DIFF
--- a/charts/nx-agents/Chart.yaml
+++ b/charts/nx-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-agents
 description: Nx Cloud Agents Helm Chart
 type: application
-version: 1.2.6
+version: 1.2.7
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-agents/templates/executor-binaries-pvc.yaml
+++ b/charts/nx-agents/templates/executor-binaries-pvc.yaml
@@ -7,17 +7,17 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nxCloud.app.labels" . | indent 4 }}
-  {{- if .Values.localExecutorBinaryStorage.annotations }}
+  {{- if .Values.controller.localExecutorBinaryStorage.annotations }}
   annotations:
     {{- toYaml .Values.controller.deployment.annotations | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.localExecutorBinaryStorage.storageClassName }}
-  storageClassName: {{ .Values.localExecutorBinaryStorage.storageClassName }}
+  {{- if .Values.controller.localExecutorBinaryStorage.storageClassName }}
+  storageClassName: {{ .Values.controller.localExecutorBinaryStorage.storageClassName }}
   {{- end}}
   resources:
     requests:
-      storage: {{ .Values.localExecutorBinaryStorage.size }}
+      storage: {{ .Values.controller.localExecutorBinaryStorage.size }}
 {{- end }}


### PR DESCRIPTION
we moved the option from `.Values.localExecutorBinaryStorage` to `.Values.localExecutorBinaryStorage.controller` so need to update all references accordingly.