### PR TITLE
chore(nx-cloud): enable use of external resource classes in app chart

### DIFF
--- a/EXTERNAL-RESOURCE-CLASSES.md
+++ b/EXTERNAL-RESOURCE-CLASSES.md
@@ -1,0 +1,255 @@
+# External Resource Classes Configuration
+
+## Overview
+
+Nx Cloud supports configuring resource classes for agents through an external ConfigMap. This feature allows you to define different resource classes for your agents without having to rebuild the Nx Cloud image or modify the Helm chart values directly.
+
+## Requirements
+
+This feature is only available with the following versions:
+
+- nx-cloud chart version >= 0.15.15
+- nx-agents chart version >= 1.2.11
+- Nx Cloud image versions 2504.01 and newer
+
+## Configuring the Application
+
+### Recommended Approach: Using extraManifests
+
+The simplest way to configure resource classes is to define the ConfigMap directly in your Helm values file using the `extraManifests` feature. This allows you to deploy the ConfigMap alongside the chart without having to create it separately:
+
+```yaml
+extraManifests:
+  resource-class-config:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: resource-class-config
+    data:
+      agentConfigs.yaml: |
+        resourceClasses:
+          - identifier: my-custom-resource-class-small
+            architecture: amd64
+          - identifier: my-custom-resource-class-medium
+            architecture: amd64
+          - identifier: my-custom-resource-class-large
+            architecture: amd64
+
+resourceClassConfiguration:
+  name: "resource-class-config"      # Name of the configmap containing resource class configuration
+  path: "agentConfigs.yaml"         # Path to the specific key within the configmap that contains the configuration
+```
+
+With this approach, you can define, deploy, and reference the ConfigMap all in one Helm values file, making it easier to manage your configuration.
+
+**Important Notes:**
+- Both `name` and `path` properties are required if this feature is used
+- The `path` value should match the key in your ConfigMap that contains the resource class configuration
+
+### Alternative Approach: Creating a ConfigMap Separately
+
+Alternatively, you can create the ConfigMap separately and then reference it in your Helm values:
+
+1. Create a ConfigMap containing your resource class configuration. The configuration should be in YAML format and follow the structure shown in the example below:
+
+```yaml
+resourceClasses:
+  - identifier: my-custom-resource-class-small
+    architecture: amd64
+
+  # Add more resource classes as needed
+
+```
+
+2. Create the ConfigMap using kubectl:
+
+```bash
+kubectl create configmap resource-class-config --from-file=agentConfigs.yaml=/path/to/your/config.yaml -n your-namespace
+```
+
+3. Update your Nx Cloud Helm values to reference the ConfigMap:
+
+```yaml
+resourceClassConfiguration:
+  name: "resource-class-config"      # Name of the configmap containing resource class configuration
+  path: "agentConfigs.yaml"         # Path to the specific key within the configmap that contains the configuration
+```
+
+## How It Works
+
+When configured, the Nx Cloud Helm chart will:
+
+1. Mount the specified ConfigMap to the Nx Cloud API and Aggregator pods
+2. Set the environment variable `NX_CLOUD_RESOURCE_CLASS_FILEPATH` to point to the mounted configuration file
+3. The Nx Cloud services will read this configuration and use it to determine the resource requirements for agent pods
+
+## Deployment
+
+Once you've configured your resource classes using one of the approaches above, deploy or upgrade your Nx Cloud Helm release:
+
+```bash
+helm upgrade nx-cloud nx-cloud/nx-cloud -f values.yaml -n nx-cloud
+```
+
+## Configuring the Workflow Controller
+
+When using custom resource classes, the Workflow Controller must be provided a list of resource classes where the identifiers match the ones provided to the application chart. The configuration follows a similar pattern but is applied to the workflow controller's values file.
+
+### Using extraManifests in the Workflow Controller
+
+```yaml
+extraManifests:
+  resourceclasses:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: agent-configuration
+    data:
+      agentConfigs.yaml: |
+        resourceClasses:
+        - platform: docker
+          architecture: amd64
+          os: linux
+          identifier: my-custom-resource-class-small
+          size: small
+          cpu: "1"
+          memory: "2Gi"
+          memoryLimit: "3.5Gi"
+          cpuLimit: "1.5"
+        - platform: docker
+          architecture: amd64
+          os: linux
+          identifier: my-custom-resource-class-medium
+          size: medium
+          cpu: "2"
+          memory: "4Gi"
+          memoryLimit: "5.5Gi"
+          cpuLimit: "3"
+        - platform: docker
+          architecture: amd64
+          os: linux
+          identifier: my-custom-resource-class-large
+          size: large
+          cpu: "3"
+          memory: "8Gi"
+          memoryLimit: "9.5Gi"
+          cpuLimit: "6"
+        # You can also configure agent affinities if needed
+        agentAffinities:
+          - affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: nx.app/node-role
+                          operator: In
+                          values:
+                            - agent
+            targetClasses:
+              - my-custom-resource-class-small
+              - my-custom-resource-class-medium
+          - affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: cloud.google.com/gke-nodepool
+                          operator: In
+                          values:
+                            - high-performance-pool
+            targetClasses:
+              - my-custom-resource-class-large
+```
+
+### Configuring the Workflow Controller Deployment
+
+In addition to creating the ConfigMap with resource classes, you need to configure the workflow controller deployment to mount the ConfigMap and set the appropriate environment variable. Add the following to your workflow controller values file:
+
+```yaml
+controller:
+  deployment:
+    # Other deployment configuration...
+    env:
+      # Other environment variables...
+      - name: K8S_RESOURCECLASS_CONFIG_PATH
+        value: "/opt/nx-cloud/resource-classes/agentConfigs.yaml"
+    volumes:
+      - name: resource-classes-config
+        configMap:
+          name: agent-configuration  # Must match the name in your extraManifests
+          items:
+            - key: agentConfigs.yaml  # Must match the key in your ConfigMap
+              path: agentConfigs.yaml
+    volumeMounts:
+      - name: resource-classes-config
+        mountPath: /opt/nx-cloud/resource-classes
+```
+
+This configuration:
+
+1. Creates a volume named `resource-classes-config` that references the ConfigMap containing your resource class definitions
+2. Mounts this volume to the path `/opt/nx-cloud/resource-classes` in the workflow controller container
+3. Sets the environment variable `K8S_RESOURCECLASS_CONFIG_PATH` to point to the specific file within the mounted volume
+
+The workflow controller will read this configuration file to determine the resource requirements for agent pods and apply the appropriate affinities when scheduling them.
+
+### Resource Class Properties
+
+#### Required Fields for API and Aggregator
+
+For the Nx Cloud API and Aggregator components, only the following fields are required:
+
+- **identifier**: Unique identifier for the resource class
+- **architecture**: CPU architecture (e.g., amd64, arm64)
+
+#### Additional Fields for Workflow Controller
+
+The following fields are required by the workflow controller in the nx-cloud-workflow-controller chart:
+
+- **identifier**: Unique identifier for the resource class
+- **architecture**: CPU architecture (e.g., amd64, arm64)
+- **platform**: The container platform (e.g., docker)
+- **os**: Operating system (e.g., linux)
+- **size**: Human-readable size name
+- **cpu**: Requested CPU resources
+- **memory**: Requested memory resources
+- **cpuLimit**: CPU limit
+- **memoryLimit**: Memory limit
+
+### Agent Affinities
+
+The `agentAffinities` section allows you to control which resource classes are scheduled on specific nodes based on node labels or other Kubernetes affinity rules. Each affinity consists of two parts:
+
+1. **affinity**: A standard Kubernetes affinity definition that determines which nodes are eligible for scheduling. This is a direct 1:1 mapping with Kubernetes affinity rules and supports all the same properties (requiredDuringSchedulingIgnoredDuringExecution, preferredDuringSchedulingIgnoredDuringExecution, etc.).
+
+2. **targetClasses**: A list of resource class identifiers that should be scheduled according to this affinity rule. These identifiers must match resource classes defined in the `resourceClasses` section.
+
+Example:
+```yaml
+agentAffinities:
+  - affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: nx.app/node-role
+                  operator: In
+                  values:
+                    - agent
+    targetClasses:
+      - my-custom-resource-class-small
+      - my-custom-resource-class-medium
+```
+
+In this example, the `my-custom-resource-class-small` and `my-custom-resource-class-medium` resource classes will only be scheduled on nodes with the label `nx.app/node-role: agent`.
+
+## Troubleshooting
+
+If you encounter issues with the resource class configuration:
+
+1. Verify that both the `name` and `path` properties are correctly set in your Helm values
+2. Check that the ConfigMap exists in the correct namespace
+3. Ensure the key specified in the `path` property exists in the ConfigMap
+4. Validate that your resource class configuration follows the correct format
+5. Check the logs of the Nx Cloud API and Aggregator pods for any error messages related to resource class configuration
+

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.14
+version: 0.15.15
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/ci/resource-class-config-values.yaml
+++ b/charts/nx-cloud/ci/resource-class-config-values.yaml
@@ -1,0 +1,136 @@
+global:
+  imageTag: '2405.02.15'
+
+nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
+
+secret:
+  name: 'cloudsecret'
+  nxCloudMongoServerEndpoint: 'NX_CLOUD_MONGO_SERVER_ENDPOINT'
+  adminPassword: 'ADMIN_PASSWORD'
+
+# Resource class configuration
+resourceClassConfiguration:
+  name: "resource-class-config"
+  path: "agentConfigs.yaml"
+
+# When creating new values files for testing, bring over the lines below. The generated environment is quite resource
+# constrained and with the default settings from values.yaml some of the pods will fail to schedule.
+frontend:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+  service:
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+nxApi:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+  service:
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+fileServer:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+    port: 5000
+  service:
+    port: 5000
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+aggregator:
+  serviceAccountName: 'nx-cloud-sa'
+  schedule: "*/10 * * * *"
+  env:
+    - name: TEST_VARIABLE
+      value: 'test'
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+messagequeue:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    port: 61616
+  service:
+    port: 61616
+
+extraManifests:
+  serviceAccount:
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: nx-cloud-sa
+      namespace: default
+  secret:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloudsecret
+      namespace: default
+    type: Opaque
+    stringData:
+      NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"
+      ADMIN_PASSWORD: "SOME_ADMIN_PASSWORD"
+      GITHUB_SECRET: "I_AM_A_SECRET_VALUE"
+      GH_CLIENT_ID: "I_AM_A_SECRET_VALUE"
+      GH_CLIENT_SECRET_VALUE: "I_AM_A_SECRET_VALUE"
+      SOME_SECRET_TOKEN: "I_AM_A_SECRET_VALUE"
+      GITLAB_ACCESS_TOKEN: "I_AM_A_SECRET_VALUE"
+      GITHUB_AUTH_CLIENT_ID: "A_GITHUB_ID"
+      GITHUB_AUTH_CLIENT_SECRET: "A_GITHUB_CLIENT_SECRET"
+      GITHUB_WEBHOOK_SECRET: "A_GITHUB_SECRET_VALUE"
+      GITHUB_AUTH_TOKEN: "A_GITHUB_SECRET_VALUE"
+      GITHUB_APP_PRIVATE_KEY: "A_GITHUB_SECRET_VALUE"
+      GITHUB_APP_ID: "A_GITHUB_SECRET_VALUE"
+      AWS_KEY: "MYAWSKEY"
+      AWS_SECRET: "SUPER_SECRET_AWS_SECRET"
+  resourceClassConfigMap:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: resource-class-config
+      namespace: default
+    data:
+      agentConfigs.yaml: |
+        resourceClasses:
+          - platform: docker
+            architecture: amd64
+            os: linux
+            identifier: docker_linux_amd64/small
+            size: small
+            cpu: "0.5"
+            memory: "1Gi"
+            memoryLimit: "2Gi"
+            cpuLimit: "1"
+          - platform: docker
+            architecture: amd64
+            os: linux
+            identifier: docker_linux_amd64/medium
+            size: medium
+            cpu: "1"
+            memory: "2Gi"
+            memoryLimit: "4Gi"
+            cpuLimit: "2"

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -32,13 +32,19 @@ spec:
           securityContext:
           {{- toYaml .Values.aggregator.securityContext | nindent 12 }}
           {{- end }}
-          {{- if .Values.selfSignedCertConfigMap }}
+          {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
           volumeMounts:
+            {{- if .Values.selfSignedCertConfigMap }}
             - mountPath: /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security
               name: cacerts
               subPath: security
             - mountPath: /self-signed-certs
               name: self-signed-certs-volume
+            {{- end }}
+            {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+            - mountPath: /opt/nx-cloud/resource-classes
+              name: resource-class-config-volume
+            {{- end }}
           {{- end}}
           env:
           {{- include "nxCloud.env.mongoSecrets" . | indent 12 }}
@@ -56,6 +62,10 @@ spec:
             - name: NX_CLOUD_DB_HASH_DETAILS_EXPIRATION_IN_DAYS
               value: '{{ .Values.clearRecordsOlderThanDays }}'
           {{- end }}
+          {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+            - name: NX_CLOUD_RESOURCE_CLASS_FILEPATH
+              value: '/opt/nx-cloud/resource-classes/agentConfigs.yaml'
+          {{- end }}
           {{- if .Values.secret.adminPassword }}
             {{- if .Values.secret.name }}
             - name: ADMIN_PASSWORD
@@ -69,13 +79,23 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
           {{- end }}
-      {{- if .Values.selfSignedCertConfigMap }}
+      {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
       volumes:
+        {{- if .Values.selfSignedCertConfigMap }}
         - emptyDir: { }
           name: cacerts
         - configMap:
             name: {{ .Values.selfSignedCertConfigMap }}
           name: self-signed-certs-volume
+        {{- end }}
+        {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+        - configMap:
+            name: {{ .Values.resourceClassConfiguration.name }}
+            items:
+              - key: {{ .Values.resourceClassConfiguration.path }}
+                path: agentConfigs.yaml
+          name: resource-class-config-volume
+        {{- end }}
       {{- end }}
       restartPolicy: OnFailure
 {{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -60,13 +60,19 @@ spec:
           securityContext:
           {{- toYaml .Values.nxApi.securityContext | nindent 12 }}
           {{- end }}
-          {{- if .Values.selfSignedCertConfigMap }}
+          {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
           volumeMounts:
+            {{- if .Values.selfSignedCertConfigMap }}
             - mountPath: /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security
               name: cacerts
               subPath: security
             - mountPath: /self-signed-certs
               name: self-signed-certs-volume
+            {{- end }}
+            {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+            - mountPath: /opt/nx-cloud/resource-classes
+              name: resource-class-config-volume
+            {{- end }}
           {{- end}}
           startupProbe:
             httpGet:
@@ -94,6 +100,10 @@ spec:
           {{- include "nxCloud.workflows.serviceTarget" . | indent 12 }}
           {{- if .Values.nxApi.deployment.env }}
             {{- toYaml .Values.nxApi.deployment.env | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+            - name: NX_CLOUD_RESOURCE_CLASS_FILEPATH
+              value: '/opt/nx-cloud/resource-classes/agentConfigs.yaml'
           {{- end }}
           {{- if .Values.enableMessageQueue }}
             - name: ACTIVEMQ_ADDRESS
@@ -152,11 +162,21 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
         {{- end }}
-      {{- if .Values.selfSignedCertConfigMap }}
+      {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
       volumes:
+        {{- if .Values.selfSignedCertConfigMap }}
         - emptyDir: { }
           name: cacerts
         - configMap:
             name: {{ .Values.selfSignedCertConfigMap }}
           name: self-signed-certs-volume
+        {{- end }}
+        {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
+        - configMap:
+            name: {{ .Values.resourceClassConfiguration.name }}
+            items:
+              - key: {{ .Values.resourceClassConfiguration.path }}
+                path: agentConfigs.yaml
+          name: resource-class-config-volume
+        {{- end }}
       {{- end }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -223,6 +223,12 @@ saml:
 selfSignedCertConfigMap: ''
 vcsHttpsProxy: ''
 
+# Optional: ConfigMap for loading resource class configuration
+# If this feature is used, both name and path must be specified
+resourceClassConfiguration:
+  name: ""      # Name of the configmap containing resource class configuration
+  path: ""      # Path to the specific key within the configmap that contains the configuration
+
 secret:
   name: ''
   nxCloudMongoServerEndpoint: ''
@@ -239,5 +245,6 @@ secret:
   githubAppClientId: ''
   githubAppClientSecret: ''
   gitlabAccessToken: ''
+
 
 extraManifests: {}


### PR DESCRIPTION
This introduces the ability to specify external resource classes to the api and aggregator
in a similar fashion to the nx-agents chart. This is primarialy needed as the api serves
as a first line to verify a provided resource class is supported by the system.
