### PR TITLE
chore(nx-cloud): ensure custom volumes and mounts can be used

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.15
+version: 0.15.16
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/ci/volume-helpers-test-values.yaml
+++ b/charts/nx-cloud/ci/volume-helpers-test-values.yaml
@@ -1,0 +1,135 @@
+global:
+  imageTag: '2405.02.15'
+
+nxCloudAppURL: 'URL_TO_ACCESS_INGRESS_FROM_DEV_MACHINES'
+
+secret:
+  name: 'cloudsecret'
+  nxCloudMongoServerEndpoint: 'NX_CLOUD_MONGO_SERVER_ENDPOINT'
+  adminPassword: 'ADMIN_PASSWORD'
+
+# Test for volume helpers
+# This test file adds custom volumes and volumeMounts to each component
+# to verify that the volume helper functions work correctly
+# Also tests resource class configuration to ensure helpers work correctly
+# when multiple volume sources are combined
+
+# Resource class configuration for testing
+resourceClassConfiguration:
+  name: "resource-class-config"
+  path: "agentConfigs.yaml"
+
+frontend:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    volumes:
+      - name: test-volume
+        emptyDir: {}
+    volumeMounts:
+      - name: test-volume
+        mountPath: /test-mount
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+  service:
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+nxApi:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    volumes:
+      - name: test-volume
+        emptyDir: {}
+    volumeMounts:
+      - name: test-volume
+        mountPath: /test-mount
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+  service:
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+aggregator:
+  serviceAccountName: 'nx-cloud-sa'
+  schedule: "*/10 * * * *"
+  volumes:
+    - name: test-volume
+      emptyDir: {}
+  volumeMounts:
+    - name: test-volume
+      mountPath: /test-mount
+  env:
+    - name: TEST_VARIABLE
+      value: 'test'
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+# Reduced resource requirements for test environment
+fileServer:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    env:
+      - name: TEST_VARIABLE
+        value: 'test'
+    port: 5000
+  service:
+    port: 5000
+    annotations:
+      my.special-annotation: "annotated"
+  resources:
+    requests:
+      memory: '0.5Mi'
+      cpu: '0.1'
+
+messagequeue:
+  serviceAccountName: 'nx-cloud-sa'
+  deployment:
+    port: 61616
+  service:
+    port: 61616
+
+extraManifests:
+  # Required service account
+  serviceAccount:
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: nx-cloud-sa
+      namespace: default
+
+  # Required secret
+  secret:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloudsecret
+      namespace: default
+    type: Opaque
+    stringData:
+      NX_CLOUD_MONGO_SERVER_ENDPOINT: "mongodb://127.0.0.1"
+      ADMIN_PASSWORD: "SOME_ADMIN_PASSWORD"
+
+  # Resource class configmap for testing
+  resourceClassConfig:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: resource-class-config
+      namespace: default
+    data:
+      agentConfigs.yaml: |
+        resourceClasses:
+          - identifier: test-resource-class
+            architecture: amd64

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -32,20 +32,7 @@ spec:
           securityContext:
           {{- toYaml .Values.aggregator.securityContext | nindent 12 }}
           {{- end }}
-          {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
-          volumeMounts:
-            {{- if .Values.selfSignedCertConfigMap }}
-            - mountPath: /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security
-              name: cacerts
-              subPath: security
-            - mountPath: /self-signed-certs
-              name: self-signed-certs-volume
-            {{- end }}
-            {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
-            - mountPath: /opt/nx-cloud/resource-classes
-              name: resource-class-config-volume
-            {{- end }}
-          {{- end}}
+          {{ include "nxCloud.volumeMounts" (dict "component" .Values.aggregator "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path)) | indent 10 }}
           env:
           {{- include "nxCloud.env.mongoSecrets" . | indent 12 }}
           {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
@@ -79,24 +66,7 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
           {{- end }}
-      {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
-      volumes:
-        {{- if .Values.selfSignedCertConfigMap }}
-        - emptyDir: { }
-          name: cacerts
-        - configMap:
-            name: {{ .Values.selfSignedCertConfigMap }}
-          name: self-signed-certs-volume
-        {{- end }}
-        {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
-        - configMap:
-            name: {{ .Values.resourceClassConfiguration.name }}
-            items:
-              - key: {{ .Values.resourceClassConfiguration.path }}
-                path: agentConfigs.yaml
-          name: resource-class-config-volume
-        {{- end }}
-      {{- end }}
+      {{ include "nxCloud.volumes" (dict "component" .Values.aggregator "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration) | indent 6 }}
       restartPolicy: OnFailure
 {{- end }}
 ---

--- a/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-frontend-deployment.yaml
@@ -51,11 +51,7 @@ spec:
           securityContext:
           {{- toYaml .Values.frontend.securityContext | nindent 12 }}
           {{- end }}
-          {{- if .Values.selfSignedCertConfigMap }}
-          volumeMounts:
-            - mountPath: /self-signed-certs
-              name: self-signed-certs-volume
-          {{- end}}
+          {{ include "nxCloud.volumeMounts" (dict "component" .Values.frontend "selfSigned" .Values.selfSignedCertConfigMap) | indent 10 }}
           env:
         {{- include "nxCloud.env.verboseLogging" . | indent 12 }}
         {{- include "nxCloud.env.mode" . | indent 12 }}
@@ -73,9 +69,4 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: /self-signed-certs/self-signed-cert.crt
         {{- end}}
-      {{- if .Values.selfSignedCertConfigMap }}
-      volumes:
-        - configMap:
-            name: {{ .Values.selfSignedCertConfigMap }}
-          name: self-signed-certs-volume
-      {{- end }}
+      {{ include "nxCloud.volumes" (dict "component" .Values.frontend "selfSigned" .Values.selfSignedCertConfigMap) | indent 6 }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -60,20 +60,7 @@ spec:
           securityContext:
           {{- toYaml .Values.nxApi.securityContext | nindent 12 }}
           {{- end }}
-          {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
-          volumeMounts:
-            {{- if .Values.selfSignedCertConfigMap }}
-            - mountPath: /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security
-              name: cacerts
-              subPath: security
-            - mountPath: /self-signed-certs
-              name: self-signed-certs-volume
-            {{- end }}
-            {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
-            - mountPath: /opt/nx-cloud/resource-classes
-              name: resource-class-config-volume
-            {{- end }}
-          {{- end}}
+          {{ include "nxCloud.volumeMounts" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path)) | indent 10 }}
           startupProbe:
             httpGet:
               path: /nx-cloud/uptime-check
@@ -162,21 +149,4 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
         {{- end }}
-      {{- if or .Values.selfSignedCertConfigMap (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) }}
-      volumes:
-        {{- if .Values.selfSignedCertConfigMap }}
-        - emptyDir: { }
-          name: cacerts
-        - configMap:
-            name: {{ .Values.selfSignedCertConfigMap }}
-          name: self-signed-certs-volume
-        {{- end }}
-        {{- if and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path }}
-        - configMap:
-            name: {{ .Values.resourceClassConfiguration.name }}
-            items:
-              - key: {{ .Values.resourceClassConfiguration.path }}
-                path: agentConfigs.yaml
-          name: resource-class-config-volume
-        {{- end }}
-      {{- end }}
+      {{ include "nxCloud.volumes" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration) | indent 6 }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -31,6 +31,8 @@ frontend:
     replicas: 1
     port: 4202
     env: []
+    volumes: []
+    volumeMounts: []
   service:
     name: nx-cloud-frontend-service
     type: ClusterIP
@@ -56,6 +58,8 @@ nxApi:
     port: 4203
     env: []
     readinessProbe: {}
+    volumes: []
+    volumeMounts: []
   service:
     name: nx-cloud-nx-api-service
     type: ClusterIP
@@ -107,6 +111,8 @@ aggregator:
     digest: ''
     pullPolicy: Always
   env: []
+  volumes: []
+  volumeMounts: []
   resources:
     limits: {}
     requests:


### PR DESCRIPTION
Internally we have a couple of extra mounts for things and we have to kustomize the yaml
output by helm. Instead let's just make it a bit easier by allowing users (and us) to
provide individual volumes. This is done in a way that still works with resource classes
and self signed certs.

Helpers were added as the conditionals were getting a bit long in the templates and tests
are included to ensure we still get what we expect.
