### PR TITLE
allow defining prebuilt java cert stores

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.16
+version: 0.15.17
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -182,7 +182,7 @@ volumes:
   - emptyDir: {}
     name: cacerts
   - configMap:
-      name: {{ $selfSigned }}
+      name: {{ default $selfSigned .Values.preBuiltJavaCertStoreConfigMap }}
     name: self-signed-certs-volume
   {{- end }}
   {{- if $resourceClass }}

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -167,6 +167,8 @@ Usage: {{ include "nxCloud.volumes" (dict "component" .Values.componentName "sel
 {{- $selfSigned := .selfSigned -}}
 {{- $resourceClass := .resourceClass -}}
 {{- $resourceClassConfig := .resourceClassConfig -}}
+{{- $isNxApi := .isNxApi -}}
+{{- $preBuiltJavaCertStoreConfigMap := .preBuiltJavaCertStoreConfigMap -}}
 {{- $hasCustomVolumes := false -}}
 {{- if $component.deployment -}}
   {{- if $component.deployment.volumes -}}
@@ -182,7 +184,7 @@ volumes:
   - emptyDir: {}
     name: cacerts
   - configMap:
-      name: {{ default $selfSigned .Values.preBuiltJavaCertStoreConfigMap }}
+      name: {{ if and $isNxApi $preBuiltJavaCertStoreConfigMap }}{{ $preBuiltJavaCertStoreConfigMap }}{{ else }}{{ $selfSigned }}{{ end }}
     name: self-signed-certs-volume
   {{- end }}
   {{- if $resourceClass }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -149,4 +149,4 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
         {{- end }}
-      {{ include "nxCloud.volumes" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration "preBuiltJavaCertStoreConfigMap" .Values.preBuiltJavaCertStoreConfigMap) | indent 6 }}
+      {{ include "nxCloud.volumes" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration "preBuiltJavaCertStoreConfigMap" .Values.preBuiltJavaCertStoreConfigMap "isNxApi" true) | indent 6 }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -149,4 +149,4 @@ spec:
             - name: NX_CLOUD_USE_MONGO42
               value: 'false'
         {{- end }}
-      {{ include "nxCloud.volumes" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration) | indent 6 }}
+      {{ include "nxCloud.volumes" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "resourceClassConfig" .Values.resourceClassConfiguration "preBuiltJavaCertStoreConfigMap" .Values.preBuiltJavaCertStoreConfigMap) | indent 6 }}

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -227,6 +227,7 @@ saml:
 # If you plan to deploy using your own self-signed certs, add them to a config map and provide the name here
 # We will mount the configmap to the pods and import the certs contained within at `self-signed-cert.crt`
 selfSignedCertConfigMap: ''
+preBuiltJavaCertStoreConfigMap: ''
 vcsHttpsProxy: ''
 
 # Optional: ConfigMap for loading resource class configuration


### PR DESCRIPTION
See the docs for an example on how they'd use this: https://github.com/nrwl/nx-cloud-helm/blob/a95fdbde3f6cbc521b0b7c7c5a853800a69ff45d/PROXY-GUIDE.md#pre-built-java-cacerts