### PR TITLE
fix(nx-cloud): make Java security path detection robust

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.15.17
+version: 0.16.0-rc.1
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.16.0-rc.2
+version: 0.16.0-rc.3
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.16.0-rc.1
+version: 0.16.0-rc.2
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.16.0-rc.3
+version: 0.16.0-rc.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -186,6 +186,9 @@ volumes:
   - configMap:
       name: {{ if and $isNxApi $preBuiltJavaCertStoreConfigMap }}{{ $preBuiltJavaCertStoreConfigMap }}{{ else }}{{ $selfSigned }}{{ end }}
     name: self-signed-certs-volume
+  - configMap:
+      name: nx-cloud-java-security-script
+    name: java-security-script
   {{- end }}
   {{- if $resourceClass }}
   - configMap:

--- a/charts/nx-cloud/templates/_helpers.tpl
+++ b/charts/nx-cloud/templates/_helpers.tpl
@@ -135,10 +135,39 @@ Usage: {{ include "nxCloud.volumeMounts" (dict "component" .Values.componentName
   {{- $hasCustomMounts = true -}}
 {{- end -}}
 
+{{/* Determine which Java version to use based on image tag */}}
+{{- $javaPath := "/usr/lib/jvm/java-21-amazon-corretto/jre/lib/security" -}}
+{{- $imageTag := "" -}}
+{{- if $component.image.tag -}}
+  {{- $imageTag = $component.image.tag | toString -}}
+{{- else if .global -}}
+  {{- $imageTag = .global | toString -}}
+{{- end -}}
+
+{{/* Default to Java 21 for 'latest' or versions >= 2505.15.0 */}}
+{{- if $imageTag -}}
+  {{- if ne $imageTag "latest" -}}
+    {{/* Normalize the version for semver comparison */}}
+    {{- $normalizedVersion := $imageTag -}}
+    
+    {{/* Handle versions without patch component */}}
+    {{- if eq (len (splitList "." $normalizedVersion)) 1 -}}
+      {{- $normalizedVersion = printf "%s.0.0" $normalizedVersion -}}
+    {{- else if eq (len (splitList "." $normalizedVersion)) 2 -}}
+      {{- $normalizedVersion = printf "%s.0" $normalizedVersion -}}
+    {{- end -}}
+    
+    {{/* Compare with semver */}}
+    {{- if semverCompare "< 2505.15.0" $normalizedVersion -}}
+      {{- $javaPath = "/usr/lib/jvm/java-17-amazon-corretto/jre/lib/security" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- if or $selfSigned $resourceClass $hasCustomMounts }}
 volumeMounts:
   {{- if $selfSigned }}
-  - mountPath: /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security
+  - mountPath: {{ $javaPath }}
     name: cacerts
     subPath: security
   - mountPath: /self-signed-certs

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -10,7 +10,7 @@ spec:
         - command:
             - sh
             - -c
-            - cp -r /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security /cacerts
+            - /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.aggregator.image" . }}
           name: copy-cacerts
           {{- if .Values.aggregator.securityContext }}
@@ -20,6 +20,8 @@ spec:
           volumeMounts:
             - mountPath: /cacerts
               name: cacerts
+            - mountPath: /scripts
+              name: java-security-script
       {{- end}}
       containers:
         - name: nx-cloud-aggregator

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -10,7 +10,8 @@ spec:
         - command:
             - sh
             - -c
-            - /scripts/find-java-security.sh
+            - |
+              chmod +x /scripts/find-java-security.sh && /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.aggregator.image" . }}
           name: copy-cacerts
           {{- if .Values.aggregator.securityContext }}

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -9,9 +9,7 @@ spec:
       initContainers:
         - command:
             - sh
-            - -c
-            - |
-              chmod +x /scripts/find-java-security.sh && /scripts/find-java-security.sh
+            - /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.aggregator.image" . }}
           name: copy-cacerts
           {{- if .Values.aggregator.securityContext }}

--- a/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-aggregator-cron.yaml
@@ -33,7 +33,7 @@ spec:
           securityContext:
           {{- toYaml .Values.aggregator.securityContext | nindent 12 }}
           {{- end }}
-          {{ include "nxCloud.volumeMounts" (dict "component" .Values.aggregator "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path)) | indent 10 }}
+          {{ include "nxCloud.volumeMounts" (dict "component" .Values.aggregator "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "global" .Values.global.imageTag) | indent 10 }}
           env:
           {{- include "nxCloud.env.mongoSecrets" . | indent 12 }}
           {{- include "nxCloud.env.verboseLogging" . | indent 12 }}

--- a/charts/nx-cloud/templates/nx-cloud-java-security-script-configmap.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-java-security-script-configmap.yaml
@@ -46,7 +46,7 @@ data:
     else
       echo "Could not find Java security directory in Corretto installation"
       # List all potential security directories for debugging
-      find /usr/lib/jvm -name "security" -type d 2>/dev/null
+      find /usr -name "security" -type d 2>/dev/null | grep -i java
       exit 1
     fi
     echo "Successfully copied Java security files from $JAVA_PATH to /cacerts"

--- a/charts/nx-cloud/templates/nx-cloud-java-security-script-configmap.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-java-security-script-configmap.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.selfSignedCertConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nx-cloud-java-security-script
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nxCloud.app.labels" . | indent 4 }}
+data:
+  find-java-security.sh: |
+    #!/bin/sh
+    # For Amazon Corretto, find the security directory dynamically
+    if [ -n "$JAVA_HOME" ]; then
+      # Use JAVA_HOME if available
+      JAVA_PATH="$JAVA_HOME"
+    else
+      # Look for Corretto installations first
+      for DIR in /usr/lib/jvm/java-*-amazon-corretto* /usr/lib/jvm/amazon-corretto-*; do
+        if [ -d "$DIR" ]; then
+          JAVA_PATH="$DIR"
+          break
+        fi
+      done
+      
+      # Fallback to any Java installation if Corretto not found
+      if [ -z "$JAVA_PATH" ]; then
+        for DIR in /usr/lib/jvm/* /usr/java/*; do
+          if [ -d "$DIR" ]; then
+            JAVA_PATH="$DIR"
+            break
+          fi
+        done
+      fi
+    fi
+    
+    # Check various possible security directory locations
+    if [ -d "$JAVA_PATH/jre/lib/security" ]; then
+      # Path found in some Corretto distributions, including Corretto 17
+      cp -r "$JAVA_PATH/jre/lib/security" /cacerts
+    elif [ -d "$JAVA_PATH/lib/security" ]; then
+      # Alternative path in some Corretto and OpenJDK distributions
+      cp -r "$JAVA_PATH/lib/security" /cacerts
+    elif [ -d "$JAVA_PATH/conf/security" ]; then
+      # Another alternative location in some JDK distributions
+      cp -r "$JAVA_PATH/conf/security" /cacerts
+    else
+      echo "Could not find Java security directory in Corretto installation"
+      # List all potential security directories for debugging
+      find /usr/lib/jvm -name "security" -type d 2>/dev/null
+      exit 1
+    fi
+    echo "Successfully copied Java security files from $JAVA_PATH to /cacerts"
+{{- end }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           securityContext:
           {{- toYaml .Values.nxApi.securityContext | nindent 12 }}
           {{- end }}
-          {{ include "nxCloud.volumeMounts" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path)) | indent 10 }}
+          {{ include "nxCloud.volumeMounts" (dict "component" .Values.nxApi "selfSigned" .Values.selfSignedCertConfigMap "resourceClass" (and .Values.resourceClassConfiguration.name .Values.resourceClassConfiguration.path) "global" .Values.global.imageTag) | indent 10 }}
           startupProbe:
             httpGet:
               path: /nx-cloud/uptime-check

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -35,9 +35,7 @@ spec:
       initContainers:
         - command:
             - sh
-            - -c
-            - |
-              chmod +x /scripts/find-java-security.sh && /scripts/find-java-security.sh
+            - /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.nxApi.image" . }}
           name: copy-cacerts
               {{- if .Values.nxApi.securityContext }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -36,7 +36,8 @@ spec:
         - command:
             - sh
             - -c
-            - /scripts/find-java-security.sh
+            - |
+              chmod +x /scripts/find-java-security.sh && /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.nxApi.image" . }}
           name: copy-cacerts
               {{- if .Values.nxApi.securityContext }}

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - command:
             - sh
             - -c
-            - cp -r /usr/lib/jvm/java-17-amazon-corretto/jre/lib/security /cacerts
+            - /scripts/find-java-security.sh
           image: {{ include "nxCloud.images.nxApi.image" . }}
           name: copy-cacerts
               {{- if .Values.nxApi.securityContext }}
@@ -46,6 +46,8 @@ spec:
           volumeMounts:
             - mountPath: /cacerts
               name: cacerts
+            - mountPath: /scripts
+              name: java-security-script
       {{- end}}
       containers:
         - name: nx-cloud-nx-api


### PR DESCRIPTION
This change improves the Java security directory detection in initContainers by:

1. Creating a centralized ConfigMap with a script that dynamically finds Java security
   directories across different distributions and versions
2. Updating both nx-api-deployment and aggregator-cron templates to use this script
3. Adding proper volume mounts and references in the helper templates

The script prioritizes Amazon Corretto installations but includes fallbacks for other
Java distributions. It checks multiple common security directory locations to ensure
compatibility with various Java versions.

This fixes issues when updating Java images where hardcoded paths may no longer exist.