### PR TITLE
Revert "feat(nx-api): do not use public launch templates by default (#161)"

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 0.16.3
+version: 0.16.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
+++ b/charts/nx-cloud/templates/nx-cloud-nx-api-deployment.yaml
@@ -78,8 +78,6 @@ spec:
           readinessProbe: {{- toYaml .Values.nxApi.deployment.readinessProbe | nindent 12 }}
           {{- end }}
           env:
-            - name: NX_CLOUD_DISABLE_PREDEFINED_LAUNCH_TEMPLATES
-              value: 'true'
           {{- include "nxCloud.env.nxCloudAppUrl" . | indent 12 }}
           {{- include "nxCloud.env.mode" . | indent 12 }}
           {{- include "nxCloud.frontend.scm.githubAppEnv" . | indent 12 }}


### PR DESCRIPTION
This reverts commit 1f70e0d6726ccc950fe33ad2a1fe423917d25c2a.
