### PR TITLE
docs(nx-cloud): document record expiration and align file server default with hash window

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 1.2.3
+version: 1.2.4
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/MIGRATION.md
+++ b/charts/nx-cloud/MIGRATION.md
@@ -153,6 +153,55 @@ charts and how their values were derived.
 | saml.enabled                      | SAML_ENTRY_POINT, SAML_CERT                               | frontend                                                    |
 | vcsHttpsProxy                     | VERSION_CONTROL_HTTPS_PROXY                               | frontend, nx-api                                            |
 
+## Configuring record and artifact expiration
+
+Pre-1.0 charts exposed a single `clearRecordsOlderThanDays` value that drove every expiration env var at once. That value has been removed in v1; expiration is now configured directly via env vars on the relevant components.
+
+The aggregator CronJob deletes Mongo records and the file server deletes cached artifacts on disk. They run independently, so it is the operator's responsibility to keep them in sync.
+
+### Important: keep the file server window longer than the hash window
+
+If the file server deletes an artifact while its hash record still exists in Mongo, cache reads for that hash will fail with "artifact not found". Always set:
+
+```
+NX_CACHE_EXPIRATION_PERIOD_IN_DAYS  >  NX_CLOUD_DB_HASH_DATA_EXPIRATION_IN_DAYS
+```
+
+A one-day buffer is usually enough.
+
+### Defaults
+
+| Component   | Env var                                          | Code default (when unset) | Chart default                                  |
+|-------------|--------------------------------------------------|---------------------------|------------------------------------------------|
+| file server | `NX_CACHE_EXPIRATION_PERIOD_IN_DAYS`             | 28                        | `29` (set in `fileServer.deployment.env`)      |
+| aggregator  | `NX_CLOUD_DB_RUN_DATA_EXPIRATION_IN_DAYS`        | 92                        | unset (falls back to code default)             |
+| aggregator  | `NX_CLOUD_DB_HASH_DATA_EXPIRATION_IN_DAYS`       | 28                        | unset (falls back to code default)             |
+| aggregator  | `NX_CLOUD_DB_HASH_DETAILS_EXPIRATION_IN_DAYS`    | 14                        | unset (falls back to code default)             |
+| aggregator  | `NX_CLOUD_DB_TERMINAL_OUTPUTS_EXPIRATION_IN_DAYS`| 14                        | unset (falls back to code default)             |
+
+The chart's default file server window (29) is one day longer than the default hash window (28), which is the safe ordering described above.
+
+### Overriding the defaults
+
+To shorten or extend retention, set the env vars directly. For example, to keep 7 days of hash data and clean files one day later:
+
+```yaml
+fileServer:
+  deployment:
+    env:
+      NX_CACHE_EXPIRATION_PERIOD_IN_DAYS: "8"
+
+aggregator:
+  cronjob:
+    env:
+      NX_CLOUD_DB_RUN_DATA_EXPIRATION_IN_DAYS: "7"
+      NX_CLOUD_DB_HASH_DATA_EXPIRATION_IN_DAYS: "7"
+      NX_CLOUD_DB_HASH_DETAILS_EXPIRATION_IN_DAYS: "7"
+      NX_CLOUD_DB_TERMINAL_OUTPUTS_EXPIRATION_IN_DAYS: "7"
+```
+
+If you only override the hash window, remember to bump the file server window to match.
+
 ## Using self-signed certificates
 
 To add self-signed certificates to a Java keystore, you can use a combination of the `initContainers`, `extraObjects` and `extraVolumes` values.

--- a/charts/nx-cloud/README.md
+++ b/charts/nx-cloud/README.md
@@ -67,7 +67,7 @@ Below is a summary table of configurable values from values.yaml.
 | fileServer.deployment.labels                                | object | {}                                          | Deployment labels for file server.                                        |
 | fileServer.deployment.podLabels                             | object | {}                                          | Pod labels for file server deployment.                                    |
 | fileServer.deployment.port                                  | int    | 5000                                        | Container port for file server.                                           |
-| fileServer.deployment.env                                   | object | { NX_CACHE_EXPIRATION_PERIOD_IN_DAYS: "1" } | Environment variables for file server.                                    |
+| fileServer.deployment.env                                   | object | { NX_CACHE_EXPIRATION_PERIOD_IN_DAYS: "29" }| Environment variables for file server.                                    |
 | fileServer.deployment.envValueFrom                          | object | {}                                          | env valueFrom references for file server.                                 |
 | fileServer.deployment.strategy.type                         | string | RollingUpdate                               | Deployment strategy type.                                                 |
 | fileServer.deployment.strategy.rollingUpdate.maxUnavailable | int    | 1                                           | Max unavailable during rolling update.                                    |

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -52,7 +52,11 @@ fileServer:
     podLabels: {}
     port: 5000
     env:
-      NX_CACHE_EXPIRATION_PERIOD_IN_DAYS: "1"
+      # Must be greater than the longest aggregator hash expiration
+      # (NX_CLOUD_DB_HASH_DATA_EXPIRATION_IN_DAYS, default 28 days) so that
+      # the file server never deletes an artifact while its hash record still
+      # exists in Mongo. Set to 29 = 28 + 1 day of safety margin.
+      NX_CACHE_EXPIRATION_PERIOD_IN_DAYS: "29"
 
     envValueFrom: {}
     #  ENV_NAME:


### PR DESCRIPTION
### The issue

- Legacy `clearRecordsOlderThanDays` removed in v1
- No replacement documented in MIGRATION.md
- File server default: 1 day
- Aggregator hash default: 28 days
- Files deleted before their hashes
- Cache reads fail for ~27 days

### The fix

- File server default: `1` → `29`
- One day past the 28-day hash window
- Added expiration section to MIGRATION.md
- Documents all four env vars
- Explains the safe-ordering rule
- Patch bump to `1.2.4`