### PR TITLE
fix(nx-cloud): NOTES.txt nil pointer when ingress.enabled is false

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 1.2.4
+version: 1.2.5
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/NOTES.txt
+++ b/charts/nx-cloud/templates/NOTES.txt
@@ -6,7 +6,11 @@
   {{- end }}
 {{- end }}
 {{- else }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=nx-cloud-frontend,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.frontend.service.port }}
+  The chart-managed Ingress is disabled. Reach the frontend through whatever
+  you've configured (externally-managed Ingress, gateway, LoadBalancer, etc.),
+  or port-forward for local testing:
+
+    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=nx-cloud-frontend,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.frontend.service.port }}
+    # then visit http://127.0.0.1:8080
 {{- end }}

--- a/charts/nx-cloud/templates/NOTES.txt
+++ b/charts/nx-cloud/templates/NOTES.txt
@@ -6,9 +6,8 @@
   {{- end }}
 {{- end }}
 {{- else }}
-  The chart-managed Ingress is disabled. Reach the frontend through whatever
-  you've configured (externally-managed Ingress, gateway, LoadBalancer, etc.),
-  or port-forward for local testing:
+  The chart-managed Ingress is disabled. Reach the frontend via your own
+  ingress, gateway, or LoadBalancer, or port-forward for local testing:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=nx-cloud-frontend,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.frontend.service.port }}

--- a/charts/nx-cloud/templates/NOTES.txt
+++ b/charts/nx-cloud/templates/NOTES.txt
@@ -5,18 +5,8 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nxCloud.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nxCloud.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nxCloud.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nxCloud.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+{{- else }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=nx-cloud-frontend,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.frontend.service.port }}
 {{- end }}


### PR DESCRIPTION
`helm install/upgrade` failed with:

```
template: nx-cloud/templates/NOTES.txt:8:39: executing "nx-cloud/templates/NOTES.txt" at <.Values.service.type>: nil pointer evaluating interface {}.type
```

`NOTES.txt` referenced `.Values.service.type`, but this chart has no top-level `service` block — service blocks live under `frontend`, `api`, `fileServer`, `workflowController`. The bug was masked when `ingress.enabled: true` but any user with ingress disabled hits it (such as all AMI users).