### PR TITLE
feat(nx-cloud): add priorityClassName

### DIFF
--- a/charts/nx-cloud/Chart.yaml
+++ b/charts/nx-cloud/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nx-cloud
 description: Nx Cloud Helm Chart
 type: application
-version: 1.2.6
+version: 1.2.7
 maintainers:
   - name: nx
     url: "https://nx.app/"

--- a/charts/nx-cloud/templates/aggregator/cronjob.yaml
+++ b/charts/nx-cloud/templates/aggregator/cronjob.yaml
@@ -45,6 +45,9 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.aggregator.cronjob.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           {{- with .Values.aggregator.cronjob.initContainers }}
           initContainers:
             {{- toYaml . | nindent 12 }}

--- a/charts/nx-cloud/templates/api/deployment.yaml
+++ b/charts/nx-cloud/templates/api/deployment.yaml
@@ -65,6 +65,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.api.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.api.deployment.initContainers }}
       initContainers:

--- a/charts/nx-cloud/templates/file-server/deployment.yaml
+++ b/charts/nx-cloud/templates/file-server/deployment.yaml
@@ -51,6 +51,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.fileServer.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/nx-cloud/templates/frontend/deployment.yaml
+++ b/charts/nx-cloud/templates/frontend/deployment.yaml
@@ -68,6 +68,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.frontend.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.frontend.deployment.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/nx-cloud/values.schema.json
+++ b/charts/nx-cloud/values.schema.json
@@ -277,6 +277,10 @@
             "tolerations": {
               "type": "array"
             },
+            "priorityClassName": {
+              "type": "string",
+              "description": "Name of a Kubernetes PriorityClass to assign to this component's pods. Controls scheduling priority and graceful node shutdown order. Defaults to empty (cluster default priority)."
+            },
             "nodeSelector": {
               "type": "object"
             },
@@ -738,6 +742,10 @@
         },
         "tolerations": {
           "type": "array"
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "Name of a Kubernetes PriorityClass to assign to this component's pods. Controls scheduling priority and graceful node shutdown order. Defaults to empty (cluster default priority)."
         },
         "nodeSelector": {
           "type": "object"

--- a/charts/nx-cloud/values.yaml
+++ b/charts/nx-cloud/values.yaml
@@ -78,6 +78,7 @@ fileServer:
     affinity: {}
     tolerations: []
     nodeSelector: {}
+    priorityClassName: ""
 
     resources:
       limits: {}
@@ -150,6 +151,7 @@ aggregator:
     affinity: {}
     tolerations: []
     nodeSelector: {}
+    priorityClassName: ""
 
     resources:
       limits: {}
@@ -216,6 +218,7 @@ frontend:
     affinity: {}
     tolerations: []
     nodeSelector: {}
+    priorityClassName: ""
 
     resources:
       limits: {}
@@ -321,6 +324,7 @@ api:
     affinity: {}
     tolerations: []
     nodeSelector: {}
+    priorityClassName: ""
 
     resources:
       limits: {}


### PR DESCRIPTION
Adds `priorityClassName` support to `api`, `frontend`, `aggregator`, and `fileServer` workloads, following the existing `nodeSelector`/`affinity`/`tolerations` pattern.